### PR TITLE
Add stop button in notification

### DIFF
--- a/android/src/main/kotlin/com/cheebeez/radio_player/RadioPlayerService.kt
+++ b/android/src/main/kotlin/com/cheebeez/radio_player/RadioPlayerService.kt
@@ -178,6 +178,10 @@ class RadioPlayerService : Service(), Player.Listener {
             override fun onNotificationCancelled(notificationId: Int, dismissedByUser: Boolean) {
                 stopForeground(true)
                 isForegroundService = false
+                // Notify the client if the playback state was changed
+                val stateIntent = Intent(ACTION_STATE_CHANGED)
+                stateIntent.putExtra(ACTION_STATE_CHANGED_EXTRA, false)
+                localBroadcastManager.sendBroadcast(stateIntent)
                 stopSelf()
             }
         }
@@ -190,6 +194,7 @@ class RadioPlayerService : Service(), Player.Listener {
             .setNotificationListener(notificationListener)
             .build().apply {
                 setUsePlayPauseActions(true)
+                setUseStopAction(true)
                 setUseFastForwardAction(false)
                 setUseFastForwardActionInCompactView(false)
                 setUseRewindAction(false)
@@ -199,6 +204,7 @@ class RadioPlayerService : Service(), Player.Listener {
                 setUsePreviousAction(false)
                 setUseNextAction(false)
                 setPlayer(player)
+
             }
     }
 


### PR DESCRIPTION
Add a stop button in the notification tray, so that users can stop the radio from notification. It is different from pause. It will cancel the notification i.e. `onNotificationCancelled` will be called.